### PR TITLE
Fix minimal interpreter to pass test_variable_keeps_value_in_different_sub_expressions

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -695,6 +695,11 @@ impl Bindings {
         BindingsIter { bindings: self, delegate: self.binding_by_var.iter() }
     }
 
+    /// An iterator visiting all variables in arbitrary order.
+    pub fn vars(&self) -> impl Iterator<Item=&VariableAtom> {
+        self.binding_by_var.keys()
+    }
+
     fn into_vec_of_pairs(mut self) -> Vec<(VariableAtom, Atom)> {
         let mut result = Vec::new();
 

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -195,7 +195,7 @@
       (eval (match-types $actual-ret-type $ret-type
         (return ())
         (return (Error $atom BadType)) ))
-      (return (Error (interpret-args $atom $args $arg-types $ret-type $space) "interpret-args expects a non-empty value for $arg-types argument")) ))
+      (return (Error $atom "Too many arguments")) ))
     (eval (if-decons-expr $args $head $tail
       (eval (if-decons-expr $arg-types $head-type $tail-types
         (chain (eval (interpret $head $head-type $space)) $reduced-head

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -131,8 +131,8 @@
           (chain (eval (foldl-atom $tail $head-folded $a $b $op)) $res (return $res)) )))
     (return $init) ))))
 
-(: divide-errors (-> Expression Expression Expression))
-(= (divide-errors $succ-err $res)
+(: separate-errors (-> Expression Expression Expression))
+(= (separate-errors $succ-err $res)
   (function (unify $succ-err ($suc $err)
     (unify $res ($a $_b)
       (eval (if-error $a
@@ -145,8 +145,8 @@
   (function
     (chain (collapse-bind $atom) $collapsed
       (chain (eval (foldl-atom $collapsed (() ()) $succ-err $res
-        (eval (divide-errors $succ-err $res)))) $divided
-        (unify $divided ($success $error)
+        (eval (separate-errors $succ-err $res)))) $separated
+        (unify $separated ($success $error)
           (chain (eval (if-equal $success () $error $success)) $filtered
             (chain (superpose-bind $filtered) $ret (return $ret)) )
           (return (Error (check-alternatives $atom) "list of results was not filtered correctly")) )))))


### PR DESCRIPTION
Main root cause is an inaccurate work with variable bindings. Standard library for minimal interpreter includes a lot of MeTTa code, and thus much more variable bindings are generated during interpretation. Most of these bindings are temporal and should be cleaned up to maximize performance. Inaccurate cleaning up causes different issues in interpreted code. This also causes 50% performance improvement for minimal MeTTa.

This PR fixes:
- work with variables for `superpose` and `collapse`: take into account variable bindings which were found between `collapse` and `superpose` of the `collapse` results. Keep variables which were collected before `collapse` is called and put by `collapse` inside resulting atoms.
- work with variables after querying atomspace, on the one hand more agressive cleanup is performed on the other hand new variables which were introduced in atoms are kept.